### PR TITLE
Export sub_404670 with metadata

### DIFF
--- a/ida_exports_u/logs/2025-05-26.md
+++ b/ida_exports_u/logs/2025-05-26.md
@@ -13,3 +13,6 @@
 
 ## 16:53:16
 - Exported `__WSAFDIsSet` at address `0x4133E0` with signature `unknown_signature`
+
+## 17:11:41
+- Exported `sub_404670` at address `0x404670` with signature `unknown_signature`

--- a/ida_exports_u/sub_404670_20250526_171141.c
+++ b/ida_exports_u/sub_404670_20250526_171141.c
@@ -1,0 +1,13 @@
+// --- Metadata ---
+// Function Name: sub_404670
+// Address: 0x404670
+// Exported At: 20250526_171141
+// Signature: unknown_signature
+// ---------------
+void *__thiscall sub_404670(void *this, char a2)
+{
+  sub_404690(this);
+  if ( (a2 & 1) != 0 )
+    operator delete(this);
+  return this;
+}


### PR DESCRIPTION
Exported `sub_404670` with address `0x404670` at 20250526_171141.